### PR TITLE
bump version to 2.1.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:
-        python-version: ["3.11.x"]
+        python-version: ["3.10.x"]
         toxenv: [ruff, isort, black, pypi-description, docs, towncrier]
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     rev: "1.16.0"
     hooks:
       - id: django-upgrade
-        args: [--target-version, "3.2"]
+        args: [--target-version, "4.2"]
   - repo: local
     hooks:
       - id: towncrier

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,17 @@ History
 
 .. towncrier release notes start
 
+2.1.0 (Unreleased)
+==================
+
+Features
+--------
+
+- Add support for Python 3.10
+- Dropped support for Python < 3.8 
+- Add support for 4.2 < Django < 5
+- Dropped support for Django < 4.2
+
 1.3.0 (2023-09-26)
 ==================
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 
 .. towncrier release notes start
 
+
 2.1.0 (Unreleased)
 ==================
 
@@ -16,6 +17,7 @@ Features
 - Dropped support for Python < 3.8 
 - Add support for 4.2 < Django < 5
 - Dropped support for Django < 4.2
+
 
 1.3.0 (2023-09-26)
 ==================

--- a/LICENSE
+++ b/LICENSE
@@ -7,6 +7,6 @@ Redistribution and use in source and binary forms, with or without modification,
 
 * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 
-* Neither the name of djangocms-page-sitemap nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+* Neither the name of djangocms-page-sitemap-fil nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ======================
-djangocms-page-sitemap
+djangocms-page-sitemap-fil
 ======================
 
 |Gitter| |PyPiVersion| |PyVersion| |Status| |TestCoverage| |CodeClimate| |License|
@@ -21,6 +21,8 @@ Supported django CMS versions:
 .. note:: djangocms-page-sitemap 0.8 has been relicensed with BSD license.
 
 .. note:: djangocms-page-sitemap 1.0 dropped compatibility with Python 2 and  Django < 2.2
+
+.. note:: djangocms-page-sitemap 2.1.0 moved to FidelityInternational org and renamed to djangocms-page-sitemap-fil dropped compatibility with Python < 3.8 and  Django < 3.2
 
 ********
 Features
@@ -150,12 +152,7 @@ Settings
 
 
 .. _page lookup: https://docs.django-cms.org/en/reference/templatetags.html#page_lookup
-.. _django-app-enabler: https://github.com/nephila/django-app-enabler
-
-
-.. |Gitter| image:: https://img.shields.io/badge/GITTER-join%20chat-brightgreen.svg?style=flat-square
-    :target: https://gitter.im/nephila/applications
-    :alt: Join the Gitter chat
+.. _django-app-enabler: https://github.com/FidelityInternational/django-app-enabler
 
 .. |PyPiVersion| image:: https://img.shields.io/pypi/v/djangocms-page-sitemap.svg?style=flat-square
     :target: https://pypi.python.org/pypi/djangocms-page-sitemap
@@ -165,18 +162,18 @@ Settings
     :target: https://pypi.python.org/pypi/djangocms-page-sitemap
     :alt: Python versions
 
-.. |Status| image:: https://img.shields.io/travis/nephila/djangocms-page-sitemap.svg?style=flat-square
-    :target: https://travis-ci.org/nephila/djangocms-page-sitemap
+.. |Status| image:: https://img.shields.io/travis/FidelityInternational/djangocms-page-sitemap-fil.svg?style=flat-square
+    :target: https://travis-ci.org/FidelityInternational/djangocms-page-sitemap-fil
     :alt: Latest Travis CI build status
 
-.. |TestCoverage| image:: https://img.shields.io/coveralls/nephila/djangocms-page-sitemap/master.svg?style=flat-square
-    :target: https://coveralls.io/r/nephila/djangocms-page-sitemap?branch=master
+.. |TestCoverage| image:: https://img.shields.io/coveralls/FidelityInternational/djangocms-page-sitemap-fil/master.svg?style=flat-square
+    :target: https://coveralls.io/r/FidelityInternational/djangocms-page-sitemap-fil?branch=master
     :alt: Test coverage
 
-.. |License| image:: https://img.shields.io/github/license/nephila/djangocms-page-sitemap.svg?style=flat-square
+.. |License| image:: https://img.shields.io/github/license/FidelityInternational/djangocms-page-sitemap-fil.svg?style=flat-square
    :target: https://pypi.python.org/pypi/djangocms-page-sitemap/
     :alt: License
 
-.. |CodeClimate| image:: https://codeclimate.com/github/nephila/djangocms-page-sitemap/badges/gpa.svg?style=flat-square
-   :target: https://codeclimate.com/github/nephila/djangocms-page-sitemap
+.. |CodeClimate| image:: https://codeclimate.com/github/FidelityInternational/djangocms-page-sitemap-fil/badges/gpa.svg?style=flat-square
+   :target: https://codeclimate.com/github/FidelityInternational/djangocms-page-sitemap-fil
    :alt: Code Climate

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 djangocms-page-sitemap-fil
 ==========================
 
-|Gitter| |PyPiVersion| |PyVersion| |Status| |TestCoverage| |CodeClimate| |License|
+|PyPiVersion| |PyVersion| |Status| |TestCoverage| |CodeClimate| |License|
 
 django CMS page extension to handle sitemap customization
 
@@ -152,7 +152,7 @@ Settings
 
 
 .. _page lookup: https://docs.django-cms.org/en/reference/templatetags.html#page_lookup
-.. _django-app-enabler: https://github.com/FidelityInternational/django-app-enabler
+.. _django-app-enabler: https://github.com/nephila/django-app-enabler
 
 .. |PyPiVersion| image:: https://img.shields.io/pypi/v/djangocms-page-sitemap.svg?style=flat-square
     :target: https://pypi.python.org/pypi/djangocms-page-sitemap

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-======================
+==========================
 djangocms-page-sitemap-fil
-======================
+==========================
 
 |Gitter| |PyPiVersion| |PyVersion| |Status| |TestCoverage| |CodeClimate| |License|
 
@@ -8,7 +8,7 @@ django CMS page extension to handle sitemap customization
 
 Support Python version:
 
-* Python 3.9, 3.10, 3.11
+* Python 3.8, 3.9, 3.10
 
 Supported Django versions:
 
@@ -16,7 +16,7 @@ Supported Django versions:
 
 Supported django CMS versions:
 
-* django CMS 3.9, 3.11
+* django CMS 4.0
 
 .. note:: djangocms-page-sitemap 0.8 has been relicensed with BSD license.
 

--- a/changes/910.feature
+++ b/changes/910.feature
@@ -1,3 +1,3 @@
 * Update tooling and ci test suite to Github Actions
-* Add compatibility with Django 3.2
+* Add compatibility with Django 4.2
 * Drop compatibility with Django < 2.2

--- a/djangocms_page_sitemap/__init__.py
+++ b/djangocms_page_sitemap/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.3.1.dev1"
+__version__ = "2.1.0"
 __author__ = "Iacopo Spalletti <i.spalletti@nephila.digital>"

--- a/djangocms_page_sitemap/addon.json
+++ b/djangocms_page_sitemap/addon.json
@@ -1,5 +1,5 @@
 {
-    "package-name": "djangocms-page-sitemap",
+    "package-name": "djangocms-page-sitemap-fil",
     "installed-apps": [
         "django.contrib.sitemaps",
         "djangocms_page_sitemap"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = "djangocms-page-sitemap"
+project = "djangocms-page-sitemap-fil"
 copyright = "2014, Iacopo Spalletti"  # noqa # A001
 
 # The version info for the project you're documenting, acts as replacement for

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
-name = djangocms-page-sitemap
+name = djangocms-page-sitemap-fil
 version = attr: djangocms_page_sitemap.__version__
-url = https://github.com/nephila/djangocms-page-sitemap
+url = https://github.com/FidelityInternational/djangocms-page-sitemap-fil
 project_urls =
 	Documentation = https://djangocms-page-sitemap.readthedocs.io/
 author = Iacopo Spalletti

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -173,7 +173,7 @@ class VersioningToolbarTest(CMSTestCase):
     @skipIf(cms.__version__ < "4.0", "Versioning not available if django CMS < 4")
     def test_toolbar_buttons_are_not_duplicated(self):
         """
-        The toolbar for djangocms-page-sitemap doesn't affect the toolbar buttons.
+        The toolbar for djangocms-page-sitemap-fil doesn't affect the toolbar buttons.
 
         This test Can be ran with or without versioning and should return the same result!
         """


### PR DESCRIPTION
2.1.0 (Unreleased)
==================

Features
--------

- Add support for Python 3.10
- Dropped support for Python < 3.8 
- Add support for 4.2 < Django < 5
- Dropped support for Django < 4.2